### PR TITLE
Update  signature and test configs to reduce warnings

### DIFF
--- a/src/fractal_helper_tasks/convert_2D_segmentation_to_3D.py
+++ b/src/fractal_helper_tasks/convert_2D_segmentation_to_3D.py
@@ -222,7 +222,4 @@ def convert_2D_segmentation_to_3D(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=convert_2D_segmentation_to_3D,
-        logger_name=logger.name,
-    )
+    run_fractal_task(task_function=convert_2D_segmentation_to_3D)

--- a/src/fractal_helper_tasks/copy_labels_multiplexing.py
+++ b/src/fractal_helper_tasks/copy_labels_multiplexing.py
@@ -71,7 +71,4 @@ def copy_labels_multiplexing(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=copy_labels_multiplexing,
-        logger_name=logger.name,
-    )
+    run_fractal_task(task_function=copy_labels_multiplexing)

--- a/src/fractal_helper_tasks/copy_labels_multiplexing_init.py
+++ b/src/fractal_helper_tasks/copy_labels_multiplexing_init.py
@@ -148,7 +148,4 @@ def copy_labels_multiplexing_init(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=copy_labels_multiplexing_init,
-        logger_name=logger.name,
-    )
+    run_fractal_task(task_function=copy_labels_multiplexing_init)

--- a/src/fractal_helper_tasks/delete_labels_tables.py
+++ b/src/fractal_helper_tasks/delete_labels_tables.py
@@ -77,7 +77,4 @@ def delete_labels_tables(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=delete_labels_tables,
-        logger_name=logger.name,
-    )
+    run_fractal_task(task_function=delete_labels_tables)

--- a/src/fractal_helper_tasks/drop_t_dimension.py
+++ b/src/fractal_helper_tasks/drop_t_dimension.py
@@ -101,7 +101,4 @@ def drop_t_dimension(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=drop_t_dimension,
-        logger_name=logger.name,
-    )
+    run_fractal_task(task_function=drop_t_dimension)

--- a/src/fractal_helper_tasks/label_assignment_by_overlap.py
+++ b/src/fractal_helper_tasks/label_assignment_by_overlap.py
@@ -227,7 +227,4 @@ def label_assignment_by_overlap(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=label_assignment_by_overlap,
-        logger_name=logger.name,
-    )
+    run_fractal_task(task_function=label_assignment_by_overlap)

--- a/src/fractal_helper_tasks/pad_images_to_same_size.py
+++ b/src/fractal_helper_tasks/pad_images_to_same_size.py
@@ -220,7 +220,4 @@ def pad_images_to_same_size(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=pad_images_to_same_size,
-        logger_name=logger.name,
-    )
+    run_fractal_task(task_function=pad_images_to_same_size)

--- a/src/fractal_helper_tasks/rechunk_zarr.py
+++ b/src/fractal_helper_tasks/rechunk_zarr.py
@@ -199,7 +199,4 @@ def rechunk_zarr(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=rechunk_zarr,
-        logger_name=logger.name,
-    )
+    run_fractal_task(task_function=rechunk_zarr)

--- a/src/fractal_helper_tasks/rename_channels.py
+++ b/src/fractal_helper_tasks/rename_channels.py
@@ -83,7 +83,4 @@ def rename_channels(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=rename_channels,
-        logger_name=logger.name,
-    )
+    run_fractal_task(task_function=rename_channels)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def zenodo_zarr(testdata_path: Path) -> list[str]:
         # 2) Copy the downloaded Zarr into tests/data
         if os.path.isdir(str(folder)):
             shutil.rmtree(str(folder))
-        shutil.copytree(Path(zarr_full_path) / file_name, folder)
+        shutil.copytree(Path(zarr_full_path) / file_name, folder, ignore=shutil.ignore_patterns(".DS_Store"))
     return [str(f) for f in folders]
 
 
@@ -77,6 +77,6 @@ def tmp_zenodo_zarr(zenodo_zarr: list[str], tmpdir: Path) -> list[str]:
     """Generates a copy of the zenodo zarrs in a tmpdir"""
     zenodo_mip_path = str(tmpdir / Path(zenodo_zarr[1]).name)
     zenodo_path = str(tmpdir / Path(zenodo_zarr[0]).name)
-    shutil.copytree(zenodo_zarr[0], zenodo_path)
-    shutil.copytree(zenodo_zarr[1], zenodo_mip_path)
+    shutil.copytree(zenodo_zarr[0], zenodo_path, ignore=shutil.ignore_patterns(".DS_Store"))
+    shutil.copytree(zenodo_zarr[1], zenodo_mip_path, ignore=shutil.ignore_patterns(".DS_Store"))
     return [zenodo_path, zenodo_mip_path]

--- a/tests/test_convert_2d_to_3d_segmentation.py
+++ b/tests/test_convert_2d_to_3d_segmentation.py
@@ -184,7 +184,10 @@ def test_2d_to_3d_z_spacing(tmp_path: Path, z):
     assert label_img_3d.shape == (10, 100, 100)
     assert ome_zarr_3d.get_label(name=label_name).pixel_size.z == z
 
-
+# nuclei table from Zenodo has wrong anndata index column type
+@pytest.mark.filterwarnings(
+    "ignore:Transforming to str index:anndata._warnings.ImplicitModificationWarning"
+)
 def test_2d_to_3d_real_data(tmp_zenodo_zarr: list[str]):
     print(tmp_zenodo_zarr)
     zarr_url = f"{tmp_zenodo_zarr[1]}/B/03/0"
@@ -217,6 +220,10 @@ def test_2d_to_3d_real_data(tmp_zenodo_zarr: list[str]):
     )
 
 
+# nuclei table from Zenodo has wrong anndata index column type
+@pytest.mark.filterwarnings(
+    "ignore:Transforming to str index:anndata._warnings.ImplicitModificationWarning"
+)
 def test_2d_to_3d_real_data_no_label_copy(tmp_zenodo_zarr: list[str]):
     print(tmp_zenodo_zarr)
     zarr_url = f"{tmp_zenodo_zarr[1]}/B/03/0"
@@ -227,7 +234,7 @@ def test_2d_to_3d_real_data_no_label_copy(tmp_zenodo_zarr: list[str]):
 
     # Add a generic table to be copied over
     generic_table = GenericTable(
-        table_data=pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+        table_data=pd.DataFrame({"col1": [1, 2], "col2": [3, 4]}, index=["0", "1"])
     )
 
     ome_zarr_2d.add_table(


### PR DESCRIPTION
I still get lots of warnings in the tests. Specifically, tons of AnnData warnings to switch to Zarr V3 & ngio warnings about not fully valid plate paths:

```
tests/test_convert_2d_to_3d_segmentation.py: 47 warnings
tests/test_copy_labels_multiplexing.py: 24 warnings
tests/test_delete_labels_tables.py: 24 warnings
tests/test_label_assignment_by_overlap.py: 5 warnings
tests/test_pad_images_to_same_size.py: 12 warnings
tests/test_rename_channels.py: 16 warnings
  /Users/joel/Documents/Code/fractal-helper-tasks/.pixi/envs/dev/lib/python3.13/site-packages/anndata/_io/zarr.py:44: UserWarning: Writing zarr v2 data will no longer be the default in the next minor release. v3 data will be written by default. If you are explicitly setting this configuration, consider migrating to the zarr v3 file format.
    f = open_write_group(store)

tests/test_rechunk_zarr.py::test_rechunk_no_overwrite_input
  /Users/joel/Documents/Code/fractal-helper-tasks/.pixi/envs/dev/lib/python3.13/site-packages/ngio/hcs/_plate.py:557: NgioUserWarning: Path '0_rechunked_custom' contains non-alphanumeric characters. This may cause issues with some tools. Consider using only alphanumeric characters in the path.
    image_path = path_in_well_validation(path=image_path)

tests/test_rechunk_zarr.py::test_rechunk_no_overwrite_input
  /Users/joel/Documents/Code/fractal-helper-tasks/.pixi/envs/dev/lib/python3.13/site-packages/ngio/ome_zarr_meta/ngio_specs/_ngio_hcs.py:53: NgioUserWarning: Path '0_rechunked_custom' contains non-alphanumeric characters. This may cause issues with some tools. Consider using only alphanumeric characters in the path.
    return path_in_well_validation(value)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

The ngio warnings only occur when specific image names are used in plates and the ngio anndata warnings are an upstream ngio topic to discuss. 